### PR TITLE
likeprotocol: Also upgrade bnft impl when lprotocol upgrade

### DIFF
--- a/likenft/scripts/upgrade.ts
+++ b/likenft/scripts/upgrade.ts
@@ -42,12 +42,47 @@ async function main() {
     }
   }
 
+  const BookNFT = await ethers.getContractFactory("BookNFT");
+  const bookNFT = await BookNFT.deploy({
+    creator: process.env.INITIAL_OWNER_ADDRESS!,
+    updaters: [],
+    minters: [],
+    config: {
+      name: "BookNFT Implementation",
+      symbol: "BOOKNFTV0",
+      metadata: "{}",
+      max_supply: 10n,
+    },
+  });
+  const newBookNFTImplementationAddress = await bookNFT.getAddress();
+  console.log(
+    "New BookNFT implementation is deployed to:",
+    newBookNFTImplementationAddress,
+  );
+
+  const upgradeToFunctionValues = [newBookNFTImplementationAddress];
+  const upgradeToFunctionFragment = LikeProtocol.interface.getFunction(
+    "upgradeTo",
+    upgradeToFunctionValues,
+  );
+  if (upgradeToFunctionFragment == null) {
+    throw new Error("upgradeTo function not found");
+  }
+  const upgradeToAndCallData = LikeProtocol.interface.encodeFunctionData(
+    upgradeToFunctionFragment,
+    upgradeToFunctionValues,
+  );
+
   // TODO: Prepare an upgrade proposal to safe
   const likeProtocol = LikeProtocol.attach(process.env.ERC721_PROXY_ADDRESS!);
   console.log("Owner:", await likeProtocol.owner());
-  await likeProtocol.upgradeToAndCall(newImplementationAddress, "0x", {
-    gasLimit: 1500000,
-  });
+  await likeProtocol.upgradeToAndCall(
+    newImplementationAddress,
+    upgradeToAndCallData,
+    {
+      gasLimit: 1500000,
+    },
+  );
 
   console.log(
     "LikeProtocol upgraded implementation to:",


### PR DESCRIPTION
Example transaction:

LikeProtocol (0x67BCd74981c33E95E5e306085754DD0A721183F1):

https://optimism-sepolia.blockscout.com/tx/0x32cb6a3b8149b906154996ca0e4cefa5b9b891bc1c4dd6d11a45d7210830cc9f?tab=logs

LikeProtocol (0x01B25559B03AA22458d286C99b9fFfd4400ad093) on dev:

https://optimism-sepolia.blockscout.com/tx/0x053a1c938d29e0d802e40802652183bd5b4037364aa6c9fa04b92dbd18d693a0?tab=logs