### PR TITLE
[WIP] likeprotocol: Add back openzeppelin deployment manifest

### DIFF
--- a/likenft/.openzeppelin/op-sepolia.json
+++ b/likenft/.openzeppelin/op-sepolia.json
@@ -159,7 +159,7 @@
             ],
             "numberOfBytes": "32"
           },
-          "t_struct(PausableStorage)829_storage": {
+          "t_struct(PausableStorage)855_storage": {
             "label": "struct PausableUpgradeable.PausableStorage",
             "members": [
               {

--- a/likenft/.openzeppelin/op-sepolia.json
+++ b/likenft/.openzeppelin/op-sepolia.json
@@ -4,6 +4,10 @@
     {
       "address": "0xfF79df388742f248c61A633938710559c61faEF1",
       "kind": "uups"
+    },
+    {
+      "address": "0x67BCd74981c33E95E5e306085754DD0A721183F1",
+      "kind": "uups"
     }
   ],
   "impls": {
@@ -212,7 +216,11 @@
             }
           ]
         }
-      }
+      },
+      "allAddresses": [
+        "0x5EB03e8226A6de4fDAD7d1eDeec461F2d4978E18",
+        "0xf7b3dfCBc1BC08cbF52b65dd27c8331fb5bdeA16"
+      ]
     }
   }
 }

--- a/likenft/.openzeppelin/op-sepolia.json
+++ b/likenft/.openzeppelin/op-sepolia.json
@@ -109,6 +109,110 @@
           ]
         }
       }
+    },
+    "f5dff1eb69553b6ded75ed3d534aa33d7b6ec67b4a1353cc413b638483080053": {
+      "address": "0x5EB03e8226A6de4fDAD7d1eDeec461F2d4978E18",
+      "txHash": "0xbb74526a2cc7bd8ff7f6db6d9d195664bdb795a6986c3905de3891fd5481a946",
+      "layout": {
+        "solcVersion": "0.8.28",
+        "storage": [],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_struct(InitializableStorage)211_storage": {
+            "label": "struct Initializable.InitializableStorage",
+            "members": [
+              {
+                "label": "_initialized",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_initializing",
+                "type": "t_bool",
+                "offset": 8,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(OwnableStorage)151_storage": {
+            "label": "struct OwnableUpgradeable.OwnableStorage",
+            "members": [
+              {
+                "label": "_owner",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(PausableStorage)829_storage": {
+            "label": "struct PausableUpgradeable.PausableStorage",
+            "members": [
+              {
+                "label": "_paused",
+                "type": "t_bool",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_uint64": {
+            "label": "uint64",
+            "numberOfBytes": "8"
+          }
+        },
+        "namespaces": {
+          "erc7201:openzeppelin.storage.Pausable": [
+            {
+              "contract": "PausableUpgradeable",
+              "label": "_paused",
+              "type": "t_bool",
+              "src": "@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol:21",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Ownable": [
+            {
+              "contract": "OwnableUpgradeable",
+              "label": "_owner",
+              "type": "t_address",
+              "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:24",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Initializable": [
+            {
+              "contract": "Initializable",
+              "label": "_initialized",
+              "type": "t_uint64",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:69",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "Initializable",
+              "label": "_initializing",
+              "type": "t_bool",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:73",
+              "offset": 8,
+              "slot": "0"
+            }
+          ]
+        }
+      }
     }
   }
 }

--- a/likenft/.openzeppelin/op-sepolia.json
+++ b/likenft/.openzeppelin/op-sepolia.json
@@ -1,0 +1,114 @@
+{
+  "manifestVersion": "3.2",
+  "proxies": [
+    {
+      "address": "0xfF79df388742f248c61A633938710559c61faEF1",
+      "kind": "uups"
+    }
+  ],
+  "impls": {
+    "846a9f713d8eddb995a06fef6e5bbc5b92d39a2a643c60a1107e582df7ed5bb0": {
+      "address": "0xC513ffcaab6f5aC669055D09f4dC0C9A3dA12c05",
+      "layout": {
+        "solcVersion": "0.8.28",
+        "storage": [],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_struct(InitializableStorage)73_storage": {
+            "label": "struct Initializable.InitializableStorage",
+            "members": [
+              {
+                "label": "_initialized",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_initializing",
+                "type": "t_bool",
+                "offset": 8,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(OwnableStorage)13_storage": {
+            "label": "struct OwnableUpgradeable.OwnableStorage",
+            "members": [
+              {
+                "label": "_owner",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(PausableStorage)219_storage": {
+            "label": "struct PausableUpgradeable.PausableStorage",
+            "members": [
+              {
+                "label": "_paused",
+                "type": "t_bool",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_uint64": {
+            "label": "uint64",
+            "numberOfBytes": "8"
+          }
+        },
+        "namespaces": {
+          "erc7201:openzeppelin.storage.Pausable": [
+            {
+              "contract": "PausableUpgradeable",
+              "label": "_paused",
+              "type": "t_bool",
+              "src": "@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol:21",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Ownable": [
+            {
+              "contract": "OwnableUpgradeable",
+              "label": "_owner",
+              "type": "t_address",
+              "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:24",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Initializable": [
+            {
+              "contract": "Initializable",
+              "label": "_initialized",
+              "type": "t_uint64",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:69",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "Initializable",
+              "label": "_initializing",
+              "type": "t_bool",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:73",
+              "offset": 8,
+              "slot": "0"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/likenft/scripts/forceImport.ts
+++ b/likenft/scripts/forceImport.ts
@@ -1,0 +1,14 @@
+import { ethers, upgrades } from "hardhat";
+
+async function main() {
+  const LikeProtocol = await ethers.getContractFactory("LikeProtocol");
+
+  await upgrades.forceImport(process.env.ERC721_PROXY_ADDRESS!, LikeProtocol);
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });


### PR DESCRIPTION
Let see if we want to switch back to LikeProtocol contract `0xfF79df388742f248c61A633938710559c61faEF1` specified in operator env

I will test all existing flows using the contract `0xfF79df388742f248c61A633938710559c61faEF1` and update backend config accordingly if no other issues.

---

Also pending likecoin to adopt.