### PR TITLE
migration-backend: Simplify do mint nft action

### DIFF
--- a/migration-backend/migrations/20250612123859-Revert likenft_migration_action_mint_nft unique index.sql
+++ b/migration-backend/migrations/20250612123859-Revert likenft_migration_action_mint_nft unique index.sql
@@ -1,0 +1,20 @@
+
+-- +migrate Up
+CREATE UNIQUE INDEX likenft_migration_action_mint_nf_evm_class_id_cosmos_nft_id_key
+ON "likenft_migration_action_mint_nft"
+(evm_class_id,cosmos_nft_id);
+
+ALTER TABLE "likenft_migration_action_mint_nft"
+ADD CONSTRAINT likenft_migration_action_mint_nf_evm_class_id_cosmos_nft_id_key
+UNIQUE USING INDEX likenft_migration_action_mint_nf_evm_class_id_cosmos_nft_id_key;
+
+DROP INDEX
+likenft_migration_action_mint_nf_evm_class_id_cosmos_nft_id_evm;
+
+-- +migrate Down
+CREATE UNIQUE INDEX likenft_migration_action_mint_nf_evm_class_id_cosmos_nft_id_evm
+ON "likenft_migration_action_mint_nft"
+(evm_class_id,cosmos_nft_id,evm_owner);
+
+ALTER TABLE "likenft_migration_action_mint_nft" DROP CONSTRAINT
+likenft_migration_action_mint_nf_evm_class_id_cosmos_nft_id_key;

--- a/migration-backend/pkg/db/likenft_migration_action_mint_nft.go
+++ b/migration-backend/pkg/db/likenft_migration_action_mint_nft.go
@@ -6,11 +6,10 @@ import (
 	"github.com/likecoin/like-migration-backend/pkg/model"
 )
 
-func QueryLikeNFTMigrationActionMintNFTByEvmClassIDAndCosmosNFTIDAndEvmOwner(
+func QueryLikeNFTMigrationActionMintNFTByEvmClassIDAndCosmosNFTID(
 	tx TxLike,
 	evmClassId string,
 	cosmosNFTId string,
-	evmOwner string,
 ) (*model.LikeNFTMigrationActionMintNFT, error) {
 	row := tx.QueryRow(`SELECT
     id,
@@ -25,8 +24,10 @@ func QueryLikeNFTMigrationActionMintNFTByEvmClassIDAndCosmosNFTIDAndEvmOwner(
 FROM likenft_migration_action_mint_nft
 WHERE
     evm_class_id = $1 AND
-    cosmos_nft_id = $2 AND
-    evm_owner = $3`, evmClassId, cosmosNFTId, evmOwner)
+    cosmos_nft_id = $2`,
+		evmClassId,
+		cosmosNFTId,
+	)
 
 	m := &model.LikeNFTMigrationActionMintNFT{}
 

--- a/migration-backend/pkg/logic/likenft/do_mint_nft_action.go
+++ b/migration-backend/pkg/logic/likenft/do_mint_nft_action.go
@@ -43,7 +43,7 @@ func DoMintNFTAction(
 	}
 	if a.Status != model.LikeNFTMigrationActionMintNFTStatusInit &&
 		a.Status != model.LikeNFTMigrationActionMintNFTStatusFailed {
-		return nil, errors.New("error new class action is not init or failed")
+		return nil, errors.New("error mint nft action is not init or failed")
 	}
 
 	nftIDMatcher := nftidmatcher.MakeNFTIDMatcher()
@@ -87,84 +87,54 @@ func DoMintNFTAction(
 
 	if !ok {
 		// arbitrary id: wnft
-
-		// Find if the cosmos nft id has initial mint (by batch mint owner)
-		// if initial mint action found
-		initialMintAction, err := appdb.QueryLikeNFTMigrationActionMintNFTByEvmClassIDAndCosmosNFTIDAndEvmOwner(
-			db, a.EvmClassId, a.CosmosNFTId, a.InitialBatchMintOwner)
-
-		if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		// Given the mint nft action is indexed by classid and nftid, the action should be simply mint.
+		//
+		// Dup check (another evm owner wants to mint the same token again) is checked
+		// when the record is retrieved by get or create
+		cosmosNFT, err := m.QueryNFT(cosmos.QueryNFTRequest{
+			ClassId: newClassAction.CosmosClassId,
+			Id:      a.CosmosNFTId,
+		})
+		if err != nil {
+			return nil, doMintNFTActionFailed(db, a, err)
+		}
+		metadataOverride, err := m.QueryNFTExternalMetadata(cosmosNFT.NFT)
+		if err != nil {
+			return nil, doMintNFTActionFailed(db, a, err)
+		}
+		metadataBytes, err := json.Marshal(evm.ERC721MetadataFromCosmosNFTAndClassAndISCNData(
+			erc721ExternalURLBuilder,
+			cosmosNFT.NFT,
+			cosmosClass.Class,
+			iscnDataResponse,
+			metadataOverride,
+			a.EvmClassId,
+			totalSupply,
+		))
+		if err != nil {
 			return nil, doMintNFTActionFailed(db, a, err)
 		}
 
-		if err != nil && errors.Is(err, sql.ErrNoRows) || initialMintAction.Id == a.Id {
-			// No initial minter, possibly is not preminted, or it is myself
-			cosmosNFT, err := m.QueryNFT(cosmos.QueryNFTRequest{
-				ClassId: newClassAction.CosmosClassId,
-				Id:      a.CosmosNFTId,
+		events, err := m.QueryAllNFTEvents(m.MakeQueryNFTEventsRequest(newClassAction.CosmosClassId, a.CosmosNFTId))
+		if err != nil {
+			return nil, doMintNFTActionFailed(db, a, err)
+		}
+
+		metadataString := string(metadataBytes)
+		tx, _, err = c.MintNFTs(
+			ctx,
+			mylogger,
+			evmClassAddress,
+			totalSupplyBigInt,
+			[]common.Address{toOwner},
+			[]string{
+				event.MakeMemoFromEvent(events),
+			},
+			[]string{
+				metadataString,
 			})
-			if err != nil {
-				return nil, doMintNFTActionFailed(db, a, err)
-			}
-			metadataOverride, err := m.QueryNFTExternalMetadata(cosmosNFT.NFT)
-			if err != nil {
-				return nil, doMintNFTActionFailed(db, a, err)
-			}
-			metadataBytes, err := json.Marshal(evm.ERC721MetadataFromCosmosNFTAndClassAndISCNData(
-				erc721ExternalURLBuilder,
-				cosmosNFT.NFT,
-				cosmosClass.Class,
-				iscnDataResponse,
-				metadataOverride,
-				a.EvmClassId,
-				totalSupply,
-			))
-			if err != nil {
-				return nil, doMintNFTActionFailed(db, a, err)
-			}
-
-			events, err := m.QueryAllNFTEvents(m.MakeQueryNFTEventsRequest(newClassAction.CosmosClassId, a.CosmosNFTId))
-			if err != nil {
-				return nil, doMintNFTActionFailed(db, a, err)
-			}
-
-			metadataString := string(metadataBytes)
-			tx, _, err = c.MintNFTs(
-				ctx,
-				mylogger,
-				evmClassAddress,
-				totalSupplyBigInt,
-				[]common.Address{toOwner},
-				[]string{
-					event.MakeMemoFromEvent(events),
-				},
-				[]string{
-					metadataString,
-				})
-			if err != nil {
-				return nil, doMintNFTActionFailed(db, a, err)
-			}
-		} else {
-			// Has initial minter but not myself
-			if initialMintAction.Status != model.LikeNFTMigrationActionMintNFTStatusCompleted {
-				return nil, doMintNFTActionFailed(db, a, errors.New("initial mint nft action not completed"))
-			}
-			transferEvent, err := c.QueryTransfer(ctx, common.HexToAddress(a.EvmClassId), common.HexToHash(*initialMintAction.EvmTxHash))
-			if err != nil {
-				return nil, doMintNFTActionFailed(db, a, err)
-			}
-			tokenId := transferEvent.TokenId
-			tx, _, err = p.TransferNFT(
-				ctx,
-				mylogger,
-				evmClassAddress,
-				initialBatchMintOwnerAddress,
-				toOwner,
-				tokenId,
-			)
-			if err != nil {
-				return nil, doMintNFTActionFailed(db, a, err)
-			}
+		if err != nil {
+			return nil, doMintNFTActionFailed(db, a, err)
 		}
 	} else {
 

--- a/migration-backend/pkg/logic/likenft/do_mint_nft_action.go
+++ b/migration-backend/pkg/logic/likenft/do_mint_nft_action.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"log/slog"
-	"math"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -137,67 +136,9 @@ func DoMintNFTAction(
 			return nil, doMintNFTActionFailed(db, a, err)
 		}
 	} else {
-
-		desireSupply := nftId + 1
-		desireBatchMintAmount := uint64(math.Max(float64(desireSupply)-float64(totalSupply), 0))
-		if desireBatchMintAmount > 0 {
-			cosmosNFTs, err := m.QueryAllNFTsByClassId(cosmos.QueryAllNFTsByClassIdRequest{
-				ClassId: newClassAction.CosmosClassId,
-			})
-
-			if err != nil {
-				return nil, doMintNFTActionFailed(db, a, err)
-			}
-
-			tos := make([]common.Address, 0)
-			memos := make([]string, 0)
-			metadataList := make([]string, 0)
-			for i := totalSupply; i < desireSupply; i = i + 1 {
-				cosmosNFT, ok := nftIDMatcher.FindCosmosNFTBySerial(cosmosNFTs.NFTs, nftId)
-				metadataStr := "{}"
-				memo := ""
-				if ok {
-					metadataOverride, err := m.QueryNFTExternalMetadata(cosmosNFT)
-					if err != nil {
-						return nil, doMintNFTActionFailed(db, a, err)
-					}
-					metadataBytes, err := json.Marshal(evm.ERC721MetadataFromCosmosNFTAndClassAndISCNData(
-						erc721ExternalURLBuilder,
-						cosmosNFT,
-						cosmosClass.Class,
-						iscnDataResponse,
-						metadataOverride,
-						a.EvmClassId,
-						nftId,
-					))
-					if err != nil {
-						return nil, doMintNFTActionFailed(db, a, err)
-					}
-					metadataStr = string(metadataBytes)
-
-					events, err := m.QueryAllNFTEvents(m.MakeQueryNFTEventsRequest(cosmosNFT.ClassId, cosmosNFT.Id))
-					if err != nil {
-						return nil, doMintNFTActionFailed(db, a, err)
-					}
-					memo = event.MakeMemoFromEvent(events)
-				}
-				tos = append(tos, initialBatchMintOwnerAddress)
-				memos = append(memos, memo)
-				metadataList = append(metadataList, metadataStr)
-			}
-			_, _, err = c.MintNFTs(
-				ctx,
-				mylogger,
-				evmClassAddress,
-				totalSupplyBigInt,
-				tos,
-				memos,
-				metadataList,
-			)
-			if err != nil {
-				return nil, doMintNFTActionFailed(db, a, err)
-			}
-		}
+		// serial nft id
+		// Assume the desire supply is prepared *by initial batch mint owner (signer)* before minting the nftid
+		// Otherwise the call will return no token error
 		tx, _, err = p.TransferNFT(
 			ctx,
 			mylogger,

--- a/migration-backend/pkg/logic/likenft/do_premint_all_nfts_action.go
+++ b/migration-backend/pkg/logic/likenft/do_premint_all_nfts_action.go
@@ -19,7 +19,9 @@ var (
 	ErrCosmosNFTIDsNotConsistent = errors.New("cosmos nftids not consistent")
 )
 
-func DoPremintAllNFTsAction(
+// Will do premint all nfts if the new class action
+// specified `ShouldPremintAllNFTs` and checked the nft ids are serial
+func DoPremintAllNFTsActionIfNeeded(
 	ctx context.Context,
 	logger *slog.Logger,
 

--- a/migration-backend/pkg/logic/likenft/get_or_create_mint_nft_action.go
+++ b/migration-backend/pkg/logic/likenft/get_or_create_mint_nft_action.go
@@ -15,11 +15,10 @@ func GetOrCreateMintNFTAction(
 	initialBatchMintOwner string,
 	evmOwner string,
 ) (*model.LikeNFTMigrationActionMintNFT, error) {
-	m, err := appdb.QueryLikeNFTMigrationActionMintNFTByEvmClassIDAndCosmosNFTIDAndEvmOwner(
+	m, err := appdb.QueryLikeNFTMigrationActionMintNFTByEvmClassIDAndCosmosNFTID(
 		db,
 		evmClassId,
 		cosmosNFTId,
-		evmOwner,
 	)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {

--- a/migration-backend/pkg/logic/likenft/migrate_class.go
+++ b/migration-backend/pkg/logic/likenft/migrate_class.go
@@ -180,7 +180,7 @@ func MigrateClass(
 
 	lastTxEvmHash = newClassAction.EvmTxHash
 
-	err = DoPremintAllNFTsAction(
+	err = DoPremintAllNFTsActionIfNeeded(
 		ctx,
 		mylogger,
 		db,

--- a/migration-backend/pkg/logic/likenft/migrate_nft.go
+++ b/migration-backend/pkg/logic/likenft/migrate_nft.go
@@ -181,7 +181,7 @@ func MigrateNFT(
 		return nil, err
 	}
 
-	err = DoPremintAllNFTsAction(
+	err = DoPremintAllNFTsActionIfNeeded(
 		ctx,
 		mylogger,
 		db,


### PR DESCRIPTION
refs likecoin/likecoin-op#106

- Assume the supply is sufficient for serial nft
- Do mint action now will simply mint WNFTs

So for now if WNFTs are preminted, the upcoming mint by users will failed with the following reason
<img width="1356" alt="image" src="https://github.com/user-attachments/assets/e1c146aa-b389-4267-9f04-1321c5bf64b5" />

And will be applied generally to any nfts (arbitrary/serial) minted.