### PR TITLE
migration-backend: Ignore url base when handle external metadata url

### DIFF
--- a/migration-backend/cmd/cli/cmd/likenft/prepare_erc721_metadata.go
+++ b/migration-backend/cmd/cli/cmd/likenft/prepare_erc721_metadata.go
@@ -1,0 +1,94 @@
+package likenft
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/likecoin/like-migration-backend/cmd/cli/config"
+	"github.com/likecoin/like-migration-backend/pkg/likenft/cosmos"
+	"github.com/likecoin/like-migration-backend/pkg/likenft/evm"
+	"github.com/likecoin/like-migration-backend/pkg/likenft/util/erc721externalurl"
+)
+
+var prepareERC721MetadataCmd = &cobra.Command{
+	Use: "prepare-erc721-metadata class-id nft-id",
+	Run: func(cmd *cobra.Command, args []string) {
+		if len(args) != 2 {
+			_ = cmd.Help()
+			return
+		}
+
+		classId := args[0]
+		nftId := args[1]
+
+		ctx := cmd.Context()
+		envCfg := ctx.Value(config.ContextKey).(*config.EnvConfig)
+
+		erc721ExternalURLBuilder, err := erc721externalurl.MakeErc721ExternalURLBuilder3ook("https://www.example.com")
+
+		if err != nil {
+			panic(err)
+		}
+
+		likenftClient := cosmos.NewLikeNFTCosmosClient(
+			envCfg.CosmosNodeUrl,
+			time.Duration(envCfg.CosmosNodeHTTPTimeoutSeconds),
+			envCfg.CosmosNftEventsIgnoreToList,
+		)
+
+		cosmosClass, err := likenftClient.QueryClassByClassId(cosmos.QueryClassByClassIdRequest{
+			ClassId: classId,
+		})
+
+		if err != nil {
+			panic(err)
+		}
+
+		iscnDataResponse, err := likenftClient.GetISCNRecord(
+			cosmosClass.Class.Data.Parent.IscnIdPrefix,
+			cosmosClass.Class.Data.Parent.IscnVersionAtMint,
+		)
+
+		if err != nil {
+			panic(err)
+		}
+
+		cosmosNFT, err := likenftClient.QueryNFT(cosmos.QueryNFTRequest{
+			ClassId: classId,
+			Id:      nftId,
+		})
+
+		if err != nil {
+			panic(err)
+		}
+
+		metadataOverride, err := likenftClient.QueryNFTExternalMetadata(cosmosNFT.NFT)
+
+		if err != nil {
+			panic(err)
+		}
+
+		metadataBytes, err := json.Marshal(evm.ERC721MetadataFromCosmosNFTAndClassAndISCNData(
+			erc721ExternalURLBuilder,
+			cosmosNFT.NFT,
+			cosmosClass.Class,
+			iscnDataResponse,
+			metadataOverride,
+			"evm-class-id",
+			10,
+		))
+
+		if err != nil {
+			panic(err)
+		}
+
+		fmt.Println(string(metadataBytes))
+	},
+}
+
+func init() {
+	LikeNFTCmd.AddCommand(prepareERC721MetadataCmd)
+}

--- a/migration-backend/pkg/likenft/cosmos/likenft_cosmos_client.go
+++ b/migration-backend/pkg/likenft/cosmos/likenft_cosmos_client.go
@@ -10,6 +10,8 @@ type LikeNFTCosmosClient struct {
 	NodeURL    string
 
 	nftEventsIgnoreToList string
+
+	nftExternalMetadataURLBaseIgnoreList []string
 }
 
 func NewLikeNFTCosmosClient(
@@ -23,5 +25,9 @@ func NewLikeNFTCosmosClient(
 		},
 		NodeURL:               nodeURL,
 		nftEventsIgnoreToList: nftEventsIgnoreToList,
+		nftExternalMetadataURLBaseIgnoreList: []string{
+			"https://api.like.co",
+			"https://api.rinkeby.like.co",
+		},
 	}
 }

--- a/migration-backend/pkg/likenft/cosmos/query_nft_external_metadata.go
+++ b/migration-backend/pkg/likenft/cosmos/query_nft_external_metadata.go
@@ -2,6 +2,7 @@ package cosmos
 
 import (
 	"encoding/json"
+	"strings"
 
 	"github.com/likecoin/like-migration-backend/pkg/likenft/cosmos/model"
 )
@@ -9,6 +10,12 @@ import (
 func (c *LikeNFTCosmosClient) QueryNFTExternalMetadata(n *model.NFT) (*model.NFTMetadata, error) {
 	if n.Uri == "" {
 		return nil, nil
+	}
+
+	for _, urlBase := range c.nftExternalMetadataURLBaseIgnoreList {
+		if strings.HasPrefix(n.Uri, urlBase) {
+			return nil, nil
+		}
 	}
 
 	resp, err := c.HTTPClient.Get(n.Uri)


### PR DESCRIPTION
Previous

```
$ go run ./cmd/cli likenft prepare-erc721-metadata likenft1ujucua5znnkmehdjqcdkmy5tttek224ggvq4ff3u3ps5h5saf6rq9ktc3a writing-30e92328-3b1f-42fa-861b-515cf21ae27b
panic: invalid character 'M' looking for beginning of value

goroutine 1 [running]:
github.com/likecoin/like-migration-backend/cmd/cli/cmd/likenft.init.func5(0x14000511c00?, {0x1400001a9e0?, 0x4?, 0x10577000c?})
        /Users/kchan/likecoin/likecoin-3.0/migration-backend/cmd/cli/cmd/likenft/prepare_erc721_metadata.go:70 +0x2c0
github.com/spf13/cobra.(*Command).execute(0x1067dd620, {0x1400001a980, 0x2, 0x2})
        /Users/kchan/.asdf/installs/golang/1.22.10/packages/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:989 +0x828
github.com/spf13/cobra.(*Command).ExecuteC(0x1067dbc40)
        /Users/kchan/.asdf/installs/golang/1.22.10/packages/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1117 +0x344
github.com/spf13/cobra.(*Command).Execute(...)
        /Users/kchan/.asdf/installs/golang/1.22.10/packages/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1041
github.com/spf13/cobra.(*Command).ExecuteContext(...)
        /Users/kchan/.asdf/installs/golang/1.22.10/packages/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1034
github.com/likecoin/like-migration-backend/cmd/cli/cmd.Execute(0x0?)
        /Users/kchan/likecoin/likecoin-3.0/migration-backend/cmd/cli/cmd/root.go:24 +0x80
main.main()
        /Users/kchan/likecoin/likecoin-3.0/migration-backend/cmd/cli/main.go:28 +0xcc
exit status 2
```

The command now should work

```
$ go run ./cmd/cli likenft prepare-erc721-metadata likenft1ujucua5znnkmehdjqcdkmy5tttek224ggvq4ff3u3ps5h5saf6rq9ktc3a writing-30e92328-3b1f-42fa-861b-515cf21ae27b
{"image":"ar://4ZyL7xNwqCKTAoB818RphBhMX3gWp44V8kGnfvRgDWBg","external_url":"https://www.example.com/evm-class-id/10","description":"Copy #10 of Geoffrey Chaucer - Simple English Wikipedia, the free encyclopedia","name":"Geoffrey Chaucer - Simple English Wikipedia, the free encyclopedia #10","attributes":[{"trait_type":"Author","value":""}],"likecoin":{"iscnIdPrefix":"iscn://likecoin-chain/ZSYZ_ZDR9Horp7C59Ms1UZ-Un0GzDDgeRQarbbz_l6Q","classId":"likenft1ujucua5znnkmehdjqcdkmy5tttek224ggvq4ff3u3ps5h5saf6rq9ktc3a","nftId":"writing-30e92328-3b1f-42fa-861b-515cf21ae27b"}}
```