### PR TITLE
migration-backend: Do not estimate nft duration with batch mint

### DIFF
--- a/migration-backend/cmd/cli/cmd/likenft/snapshot_cosmos_state.go
+++ b/migration-backend/cmd/cli/cmd/likenft/snapshot_cosmos_state.go
@@ -9,7 +9,6 @@ import (
 	"github.com/likecoin/like-migration-backend/cmd/cli/config"
 	"github.com/likecoin/like-migration-backend/pkg/cosmos/api"
 	"github.com/likecoin/like-migration-backend/pkg/likenft/cosmos"
-	"github.com/likecoin/like-migration-backend/pkg/likenft/util/nftidmatcher"
 	"github.com/likecoin/like-migration-backend/pkg/logic/likenft"
 )
 
@@ -46,7 +45,6 @@ var initMigration = &cobra.Command{
 			DB:                  db,
 			CosmosAPI:           cosmosAPI,
 			LikeNFTCosmosClient: likenftClient,
-			CosmosNFTIDMatcher:  nftidmatcher.MakeNFTIDMatcher(),
 
 			ClassMigrationEstimatedDuration: time.Duration(envCfg.ClassMigrationEstimatedDurationSeconds) * time.Second,
 			NFTMigrationEstimatedDuration:   time.Duration(envCfg.NFTMigrationEstimatedDurationSeconds) * time.Second,

--- a/migration-backend/pkg/handler/likenft/migration_preview/create.go
+++ b/migration-backend/pkg/handler/likenft/migration_preview/create.go
@@ -10,12 +10,12 @@ import (
 	"time"
 
 	"github.com/getsentry/sentry-go"
+
 	"github.com/likecoin/like-migration-backend/pkg/cosmos/api"
 	"github.com/likecoin/like-migration-backend/pkg/db"
 	"github.com/likecoin/like-migration-backend/pkg/handler"
 	api_model "github.com/likecoin/like-migration-backend/pkg/handler/model"
 	"github.com/likecoin/like-migration-backend/pkg/likenft/cosmos"
-	"github.com/likecoin/like-migration-backend/pkg/likenft/util/nftidmatcher"
 	"github.com/likecoin/like-migration-backend/pkg/logic/likenft"
 	"github.com/likecoin/like-migration-backend/pkg/model"
 )
@@ -74,7 +74,6 @@ func (h *CreateMigrationPreviewHandler) ServeHTTP(w http.ResponseWriter, r *http
 			DB:                  h.Db,
 			CosmosAPI:           h.CosmosAPI,
 			LikeNFTCosmosClient: h.LikeNFTCosmosClient,
-			CosmosNFTIDMatcher:  nftidmatcher.MakeNFTIDMatcher(),
 
 			ClassMigrationEstimatedDuration: h.ClassMigrationEstimatedDuration,
 			NFTMigrationEstimatedDuration:   h.NFTMigrationEstimatedDuration,

--- a/migration-backend/pkg/logic/likenft/snapshot_cosmos_state.go
+++ b/migration-backend/pkg/logic/likenft/snapshot_cosmos_state.go
@@ -10,7 +10,6 @@ import (
 	"github.com/likecoin/like-migration-backend/pkg/cosmos/api"
 	appdb "github.com/likecoin/like-migration-backend/pkg/db"
 	"github.com/likecoin/like-migration-backend/pkg/likenft/cosmos"
-	"github.com/likecoin/like-migration-backend/pkg/likenft/util/nftidmatcher"
 	"github.com/likecoin/like-migration-backend/pkg/model"
 )
 
@@ -18,7 +17,6 @@ type SnapshotCosmosStateLogic struct {
 	DB                  *sql.DB
 	CosmosAPI           *api.CosmosAPI
 	LikeNFTCosmosClient *cosmos.LikeNFTCosmosClient
-	CosmosNFTIDMatcher  nftidmatcher.CosmosNFTIDMatcher
 
 	ClassMigrationEstimatedDuration time.Duration
 	NFTMigrationEstimatedDuration   time.Duration
@@ -83,11 +81,7 @@ func (l *SnapshotCosmosStateLogic) Execute(ctx context.Context, cosmosAddress st
 	snapshotNFTs := make([]model.LikeNFTAssetSnapshotNFT, 0, len(cosmosNFTs.NFTs))
 
 	for _, cosmosNFT := range cosmosNFTs.NFTs {
-		estimatedDurationNeeded := time.Duration(0)
-		serialID, yes := l.CosmosNFTIDMatcher.ExtractSerialID(cosmosNFT.NFT.Id)
-		if yes {
-			estimatedDurationNeeded = time.Duration(serialID) * l.NFTMigrationEstimatedDuration
-		}
+		estimatedDurationNeeded := l.NFTMigrationEstimatedDuration
 
 		snapshotNFTs = append(snapshotNFTs, model.LikeNFTAssetSnapshotNFT{
 			NFTSnapshotId: latestSnapshot.Id,


### PR DESCRIPTION
refs likecoin/likecoin-op#114

Found an issue where the serial nfts will be estimated with batch mint and will probably overlapping with any in progress nfts of the same class id. So just remove the consideration of serial and put the configured estimation to the migration item.

It should resolve the super long migration time resulted. But may under estimate too much when a nft of a new class with large nft id that need to be pre-minted.

---

Seems can't find a simple way to account for the possibility of pre-mint without double counting the duration of individual nfts if we didn't implement a logic to consider
- current supply on chain
- consolidate the nfts that will be migrated under the same class and dedupe the pre-mint duration