### PR TITLE
deploy: Make timescaleDb depends on likecollectiveIndexer.enabled

### DIFF
--- a/deploy/helm/templates/likecollective-indexer-timescale-db-migrate.yaml
+++ b/deploy/helm/templates/likecollective-indexer-timescale-db-migrate.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.likecollectiveIndexer.enabled }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -40,3 +41,4 @@ spec:
           {{- toYaml .Values.likecollectiveIndexer.resources | nindent 12 }}
       restartPolicy: "{{ .Values.likecollectiveIndexer.migrate.restartPolicy | default "Never" }}"
   backoffLimit: {{ .Values.likecollectiveIndexer.migrate.backoffLimit | default 1 }}
+{{- end }}

--- a/deploy/helm/templates/likecollective-indexer-timescale-db.yaml
+++ b/deploy/helm/templates/likecollective-indexer-timescale-db.yaml
@@ -1,13 +1,14 @@
+{{- if .Values.likecollectiveIndexer.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app: {{ .Values.likecollectiveIndexer.timescaleDb.name }}
-  name: {{ .Values.likecollectiveIndexer.timescaleDb.name }}
+    app: {{ .Values.likecollectiveIndexer.name }}-timescale-db
+  name: {{ .Values.likecollectiveIndexer.name }}-timescale-db
   namespace: {{ .Values.namespace }}
 spec:
   selector:
-    app.kubernetes.io/component: {{ .Values.likecollectiveIndexer.timescaleDb.name }}
+    app.kubernetes.io/component: {{ .Values.likecollectiveIndexer.name }}-timescale-db
   ports:
   - protocol: TCP
     port: {{ .Values.likecollectiveIndexer.timescaleDb.service.port }}
@@ -18,7 +19,7 @@ kind: Secret
 metadata:
   labels:
     app.kubernetes.io/component: {{ .Values.likecollectiveIndexer.name }}
-  name: {{ .Values.likecollectiveIndexer.timescaleDb.name }}
+  name: {{ .Values.likecollectiveIndexer.name }}-timescale-db
   namespace: {{ .Values.namespace }}
 type: Opaque
 data:
@@ -30,43 +31,43 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app.kubernetes.io/component: {{ .Values.likecollectiveIndexer.timescaleDb.name }}
-  name: {{ .Values.likecollectiveIndexer.timescaleDb.name }}
+    app.kubernetes.io/component: {{ .Values.likecollectiveIndexer.name }}-timescale-db
+  name: {{ .Values.likecollectiveIndexer.name }}-timescale-db
   namespace: {{ .Values.namespace }}
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app.kubernetes.io/component: {{ .Values.likecollectiveIndexer.timescaleDb.name }}
+      app.kubernetes.io/component: {{ .Values.likecollectiveIndexer.name }}-timescale-db
   template:
     metadata:
       labels:
-        app.kubernetes.io/component: {{ .Values.likecollectiveIndexer.timescaleDb.name }}
+        app.kubernetes.io/component: {{ .Values.likecollectiveIndexer.name }}-timescale-db
     spec:
       restartPolicy: Always
       volumes:
-      - name: {{ .Values.likecollectiveIndexer.timescaleDb.name }}-psql-volume
+      - name: {{ .Values.likecollectiveIndexer.name }}-timescale-db-psql-volume
         persistentVolumeClaim:
-          claimName: {{ .Values.likecollectiveIndexer.timescaleDb.name }}-psql-volume-pvc
+          claimName: {{ .Values.likecollectiveIndexer.name }}-timescale-db-psql-volume-pvc
       containers:
-      - name: {{ .Values.likecollectiveIndexer.timescaleDb.name }}
+      - name: {{ .Values.likecollectiveIndexer.name }}-timescale-db
         image: {{ .Values.likecollectiveIndexer.timescaleDb.container.image }}
         imagePullPolicy: {{ .Values.likecollectiveIndexer.timescaleDb.container.imagePullPolicy }}
         envFrom:
           - secretRef:
-              name: {{ .Values.likecollectiveIndexer.timescaleDb.name }}
+              name: {{ .Values.likecollectiveIndexer.name }}-timescale-db
         ports:
         - containerPort: {{ .Values.likecollectiveIndexer.timescaleDb.container.port }}
         resources:
           {{- toYaml .Values.likecollectiveIndexer.timescaleDb.resources | nindent 12 }}
         volumeMounts:
-        - name: {{ .Values.likecollectiveIndexer.timescaleDb.name }}-psql-volume
+        - name: {{ .Values.likecollectiveIndexer.name }}-timescale-db-psql-volume
           mountPath: /var/lib/postgresql/data
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: {{ .Values.likecollectiveIndexer.timescaleDb.name }}-psql-volume-pvc
+  name: {{ .Values.likecollectiveIndexer.name }}-timescale-db-psql-volume-pvc
   namespace: {{ .Values.namespace }}
 spec:
   accessModes:
@@ -75,3 +76,4 @@ spec:
     requests:
       storage: {{ .Values.likecollectiveIndexer.timescaleDb.psqlVolume.storage }}
   storageClassName: {{ .Values.likecollectiveIndexer.timescaleDb.psqlVolume.storageClass }}
+{{- end }}

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -223,8 +223,6 @@ likecollectiveIndexer:
         resources: {}
 
   timescaleDb:
-    name: likecollective-indexer-timescale-db
-
     container:
       image: timescale/timescaledb-ha:pg16
       imagePullPolicy: IfNotPresent


### PR DESCRIPTION
What's the potential problem? I assume it will only result in some request fail during the upgrade, no data inconsistence.

it this is the case, we can live with it. Zero downtime during migration is not objective for now.