### PR TITLE
likenft-indexder: Update nft_classes.owner_address when update owner

### DIFF
--- a/likenft-indexer/internal/database/nftclass.go
+++ b/likenft-indexer/internal/database/nftclass.go
@@ -314,6 +314,7 @@ func (r *nftClassRepository) UpdateOwner(
 		}
 		return r.dbService.Client().NFTClass.Update().
 			SetOwner(newOwner).
+			SetOwnerAddress(newOwner.EvmAddress).
 			Where(nftclass.AddressEqualFold(address)).
 			Exec(ctx)
 	})


### PR DESCRIPTION
refs likecoin/likecoin-op#192

To test:

```
go run ./cmd/cli process-evm-event {evm event of ownership transfer of a booknft}
```